### PR TITLE
feat: no SMS & Whatsapp double signup validation

### DIFF
--- a/ckanext/dataset_subscriptions/actions/user.py
+++ b/ckanext/dataset_subscriptions/actions/user.py
@@ -146,6 +146,10 @@ def _validate_plugin_extras(extras):
             errors['activity_streams_sms_notifications'] = [
                 toolkit._('No phone number given')
             ]
+        if toolkit.asbool(extras.get('activity_streams_whatsapp_notifications')):
+            errors['activity_streams_sms_notifications'] = [
+                toolkit._('Please select either Whatsapp or SMS notifications - not both. ')
+            ]
     if toolkit.asbool(extras.get('activity_streams_whatsapp_notifications')):
         if not extras.get('phonenumber'):
             errors['activity_streams_whatsapp_notifications'] = [

--- a/ckanext/dataset_subscriptions/tests/actions/test_user.py
+++ b/ckanext/dataset_subscriptions/tests/actions/test_user.py
@@ -58,10 +58,11 @@ class TestUserActions():
             helpers.call_action('user_create', context=sysadmin_context, **user_dict)
 
     @pytest.mark.parametrize('phonenumber, enable_sms, enable_whatsapp, expectation', [
-        ("", False, False, nullcontext(1)),
+        ("+44712345678", False, False, nullcontext(1)),
         ("", False, True, pytest.raises(toolkit.ValidationError)),
         ("", True, False, pytest.raises(toolkit.ValidationError)),
-        ("", True, True, pytest.raises(toolkit.ValidationError))
+        ("", True, True, pytest.raises(toolkit.ValidationError)),
+        ("+44712345678", True, True, pytest.raises(toolkit.ValidationError)),
     ])
     def test_user_validate_plugin_extras_requires_phonenumber(self, phonenumber, enable_sms,
                                                               enable_whatsapp, expectation, sysadmin_context):


### PR DESCRIPTION
## Description

As requested by the client, ensures no users can sign up to both SMS and Whatsapp notifications. 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The GitHub ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
